### PR TITLE
Light refactoring.

### DIFF
--- a/GraphDSL/GraphZipper.fs
+++ b/GraphDSL/GraphZipper.fs
@@ -95,9 +95,9 @@ let tryForceMovement
     |> Seq.tryFind (fun vert -> vert = v)
     |> Option.map (fun next ->
         { Cursor = next
-        // I've used the first edge in the graph as a dummy edge to use in the
-        // cons function since it expects an edge despite not using it and I'm
-        // not sure how to change it to not need one. :P
+          // I've used the first edge in the graph as a dummy edge to use in the
+          // cons function since it expects an edge despite not using it and I'm
+          // not sure how to change it to not need one. :P
           History = (cons z.Cursor (Seq.first g.Edges).Value) :: z.History })
 
 // Added by Samuel Smith n7581769.

--- a/GraphDSL/TranscriptionFactor.fs
+++ b/GraphDSL/TranscriptionFactor.fs
@@ -33,7 +33,8 @@ let pEvidenceType: P<EvidenceType> =
 type TFName = TFName of string
 
 let pTFName: P<TFName> =
-    many1Satisfy (fun c -> isAsciiLetter c || "-".Contains(c) || isDigit c) |>> TFName
+    many1Satisfy (fun c -> isAsciiLetter c || "-".Contains(c) || isDigit c)
+    |>> TFName
 
 // An individual Transaction Factor line is composed of the following components.
 


### PR DESCRIPTION
* don't need to use `if` expressions to return booleans if the condition is equivalent
* json shouldn't be able to decode a logicaloperation that doesn't match one of the defined union values
* by using a fold we can avoid having to check if we only have a single filter, everything should work.
